### PR TITLE
Fix relative path to background images in css

### DIFF
--- a/resources/css/index.css
+++ b/resources/css/index.css
@@ -80,7 +80,7 @@ main {
 .hero-image {
     margin-top: 70px;
     height: 700px;
-    background: url(/resources/img/img-mission-background.jpeg);
+    background: url(../img/img-mission-background.jpeg);
     background-size: cover;
     display: flex;
     justify-content: center;
@@ -159,7 +159,7 @@ main {
 /* ----------- LOCATIONS ----------- */
 .locations {
     width: 90%;
-    background: linear-gradient( rgba(0, 0, 0, 0.5) 100%, rgba(0, 0, 0, 0.5)100%), url(/resources/img/img-locations-background.jpeg);
+    background: linear-gradient( rgba(0, 0, 0, 0.5) 100%, rgba(0, 0, 0, 0.5)100%), url(../img/img-locations-background.jpeg);
     background-size: cover;
     padding: 60px 0; 
     margin: 60px auto;


### PR DESCRIPTION
# Description
Fixed background images specified in CSS not showing up as described in [this forum post on codecademy](https://discuss.codecademy.com/t/background-image-is-not-showing-in-github-pages/675682). 

# Root Error
Incorrect pathing in the CSS file. The previous commit tries to reference as relative to the root directory / and not relative to the directory of the CSS file. See this [Stackoverflow post](https://stackoverflow.com/questions/940451/using-relative-url-in-css-file-what-location-is-it-relative-to) for more information.